### PR TITLE
Radiant changes

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -10,6 +10,7 @@ python-dateutil<2.9
 stem>=1.8.0
 certifi
 pathvalidate
+pycryptodome
 
 # Note that we also need the dnspython[DNSSEC] extra which pulls in cryptography,
 # but as that is not pure-python it cannot be listed in this file!

--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -340,8 +340,8 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
 
     _NUM_FMTS = 3  # <-- Be sure to update this if you add a format above!
 
-    # Default to CashAddr
-    FMT_UI = FMT_CASHADDR
+    # Default to legacy
+    FMT_UI = FMT_LEGACY
 
     def __new__(cls, hash160, kind):
         assert kind in (cls.ADDR_P2PKH, cls.ADDR_P2SH)

--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -25,6 +25,7 @@
 # SOFTWARE.
 
 import hashlib
+from Crypto.Hash import SHA512
 import base64
 import hmac
 import os
@@ -413,6 +414,16 @@ def Hash(x):
     out = bytes(sha256(sha256(x)))
     return out
 
+def sha512_256(x):
+    x = to_bytes(x, 'utf8')
+    h = SHA512.new(truncate="256")
+    h.update(x)
+    return bytes(h.digest())
+
+def RadiantHash(x):
+    x = to_bytes(x, 'utf8')
+    out = bytes(sha512_256(sha512_256(x)))
+    return out
 
 def hmac_oneshot(key, msg, digest):
     """ Params key, msg and return val are bytes.

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -146,7 +146,7 @@ def deserialize_header(s, height):
     return h
 
 def hash_header_hex(header_hex):
-    return hash_encode(Hash(bfh(header_hex)))
+    return hash_encode(RadiantHash(bfh(header_hex)))
 
 def hash_header(header):
     if header is None:

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -1760,7 +1760,7 @@ class Network(util.DaemonThread):
                                   .format(networks.net.VERIFICATION_BLOCK_MERKLE_ROOT, merkle_root))
             return False
 
-        header_hash = Hash(bfh(header))
+        header_hash = RadiantHash(bfh(header))
         byte_branches = [bfh(v)[::-1] for v in merkle_branch]
         proven_merkle_root = blockchain.root_from_proof(header_hash, byte_branches, header_height)
         if proven_merkle_root != expected_merkle_root:

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -72,13 +72,13 @@ class MainNet(AbstractNet):
     #    network.synchronous_get(("blockchain.block.header", [height, height]))
     #
     # Consult the ElectrumX documentation for more details.
-    VERIFICATION_BLOCK_MERKLE_ROOT = "60b3f9f9e439fd5f6c95ae380b91a480359657afd9206a9274f66fd42845273b"
-    VERIFICATION_BLOCK_HEIGHT = 717171
+    VERIFICATION_BLOCK_MERKLE_ROOT = "6cafe6844c6f42085778412ce6415e810cbfb030a505ba9731e29bde72097421"
+    VERIFICATION_BLOCK_HEIGHT = 18144
     asert_daa = ASERTDaa(is_testnet=False)
     # Note: We *must* specify the anchor if the checkpoint is after the anchor, due to the way
     # blockchain.py skips headers after the checkpoint.  So all instances that have a checkpoint
     # after the anchor must specify the anchor as well.
-    asert_daa.anchor = Anchor(height=661647, bits=402971390, prev_time=1605447844)
+    asert_daa.anchor = Anchor(height=18206, bits=453224288, prev_time=1657404650)
 
     # Version numbers for BIP32 extended keys
     # standard: xprv, xpub

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -40,8 +40,8 @@ class AbstractNet:
     LEGACY_POW_TARGET_TIMESPAN = 14 * 24 * 60 * 60   # 2 weeks
     LEGACY_POW_TARGET_INTERVAL = 10 * 60  # 10 minutes
     LEGACY_POW_RETARGET_BLOCKS = LEGACY_POW_TARGET_TIMESPAN // LEGACY_POW_TARGET_INTERVAL  # 2016 blocks
-    BASE_UNITS = {'BCH': 8, 'mBCH': 5, 'bits': 2}
-    DEFAULT_UNIT = "BCH"
+    BASE_UNITS = {'RAD': 8, 'mRAD': 5, 'bits': 2}
+    DEFAULT_UNIT = "RAD"
 
 
 class MainNet(AbstractNet):
@@ -103,8 +103,8 @@ class TestNet(AbstractNet):
     DEFAULT_PORTS = {'t':'51001', 's':'51002'}
     DEFAULT_SERVERS = _read_json_dict('servers_testnet.json')  # DO NOT MODIFY IN CLIENT CODE
     TITLE = 'Electron Radiant Testnet'
-    BASE_UNITS = {'tBCH': 8, 'mtBCH': 5, 'tbits': 2}
-    DEFAULT_UNIT = "tBCH"
+    BASE_UNITS = {'tRAD': 8, 'mtRAD': 5, 'tbits': 2}
+    DEFAULT_UNIT = "tRAD"
 
     # Nov 13. 2017 HF to CW144 DAA height (height of last block mined on old DAA)
     CW144_HEIGHT = 1188697
@@ -153,8 +153,8 @@ class TestNet4(TestNet):
 class ScaleNet(TestNet):
     GENESIS = "00000000e6453dc2dfe1ffa19023f86002eb11dbb8e87d0291a4599f0430be52"
     TITLE = 'Electron Cash Scalenet'
-    BASE_UNITS = {'sBCH': 8, 'msBCH': 5, 'sbits': 2}
-    DEFAULT_UNIT = "tBCH"
+    BASE_UNITS = {'sRAD': 8, 'msRAD': 5, 'sbits': 2}
+    DEFAULT_UNIT = "tRAD"
 
 
     HEADERS_URL = "http://bitcoincash.com/files/scalenet_headers"  # Unused

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -55,7 +55,7 @@ class MainNet(AbstractNet):
     GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
     DEFAULT_PORTS = {'t': '50001', 's': '50002'}
     DEFAULT_SERVERS = _read_json_dict('servers.json')  # DO NOT MODIFY IN CLIENT CODE
-    TITLE = 'Electron Cash'
+    TITLE = 'Electron Radiant'
 
     # Bitcoin Cash fork block specification
     BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
@@ -102,7 +102,7 @@ class TestNet(AbstractNet):
     GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
     DEFAULT_PORTS = {'t':'51001', 's':'51002'}
     DEFAULT_SERVERS = _read_json_dict('servers_testnet.json')  # DO NOT MODIFY IN CLIENT CODE
-    TITLE = 'Electron Cash Testnet'
+    TITLE = 'Electron Radiant Testnet'
     BASE_UNITS = {'tBCH': 8, 'mtBCH': 5, 'tbits': 2}
     DEFAULT_UNIT = "tBCH"
 

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -38,7 +38,7 @@ class SimpleConfig(PrintError):
         2. User configuration (in the user's config directory)
     They are taken in order (1. overrides config options set in 2.)
     """
-    fee_rates = [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]
+    fee_rates = [1000000, 2000000, 3000000, 4000000, 5000000, 6000000, 7000000, 8000000, 9000000, 10000000]
 
     def __init__(self, options=None, read_user_config_function=None,
                  read_user_dir_function=None):

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -45,8 +45,8 @@ def inv_dict(d):
     return {v: k for k, v in d.items()}
 
 
-DEFAULT_BASE_UNIT = "BCH"
-base_units = {'BCH':8, 'mBCH':5, 'bits':2}
+DEFAULT_BASE_UNIT = "RAD"
+base_units = {'RAD':8, 'mRAD':5, 'bits':2}
 
 inv_base_units = {}
 base_unit_labels = tuple()

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -471,14 +471,14 @@ def user_dir(prefer_local=False):
     if 'ANDROID_DATA' in os.environ:
         return android_data_dir()
     elif os.name == 'posix' and "HOME" in os.environ:
-        return os.path.join(os.environ["HOME"], ".electron-cash" )
+        return os.path.join(os.environ["HOME"], ".electron-radiant" )
     elif "APPDATA" in os.environ or "LOCALAPPDATA" in os.environ:
         app_dir = os.environ.get("APPDATA")
         localapp_dir = os.environ.get("LOCALAPPDATA")
         # Prefer APPDATA, but may get LOCALAPPDATA if present and req'd.
         if localapp_dir is not None and prefer_local or app_dir is None:
             app_dir = localapp_dir
-        return os.path.join(app_dir, "ElectronCash")
+        return os.path.join(app_dir, "ElectronRadiant")
     else:
         #raise Exception("No home directory found in environment variables.")
         return

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2006,11 +2006,11 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             outputs[i_max] = (_type, data, amount)
             tx = Transaction.from_io(inputs, outputs, sign_schnorr=sign_schnorr)
 
-        # If user tries to send too big of a fee (more than 50 sat/byte), stop them from shooting themselves in the foot
+        # If user tries to send too big of a fee (more than 50000 sat/byte), stop them from shooting themselves in the foot
         tx_in_bytes=tx.estimated_size()
         fee_in_satoshis=tx.get_fee()
         sats_per_byte=fee_in_satoshis/tx_in_bytes
-        if (sats_per_byte > 50):
+        if (sats_per_byte > 50000):
             raise ExcessiveFee()
 
         # Sort the inputs and outputs deterministically

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2693,40 +2693,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
     def is_schnorr_enabled(self) -> bool:
         ''' Returns whether schnorr is enabled AND possible for this wallet.
         Schnorr is enabled per-wallet. '''
-        if not self.is_schnorr_possible():
-            # Short-circuit out of here -- it's not even possible with this
-            # wallet type.
-            return False
-        ss_cfg = self.storage.get('sign_schnorr', None)
-        if ss_cfg is None:
-            # Schnorr was not set in config; figure out intelligent defaults,
-            # preferring Schnorr if it's at least as fast as ECDSA (based on
-            # which libs user has installed). Note for watching-only we default
-            # to off if unspecified regardless, to not break compatibility
-            # with air-gapped signing systems that have older EC installed
-            # on the signing system. This is to avoid underpaying fees if
-            # signing system doesn't use Schnorr.  We can turn on default
-            # Schnorr on watching-only sometime in the future after enough
-            # time has passed that air-gapped systems are unlikely to not
-            # have Schnorr enabled by default.
-            # TO DO: Finish refactor of txn serialized format to handle this
-            # case better!
-            if (not self.is_watching_only()
-                    and (schnorr.has_fast_sign()
-                         or not ecc_fast.is_using_fast_ecc())):
-                # Prefer Schnorr, all things being equal.
-                # - If not watching-only & schnorr possible AND
-                # - Either Schnorr is fast sign (native, ABC's secp256k1),
-                #   so use it by default
-                # - Or both ECDSA & Schnorr are slow (non-native);
-                #   so use Schnorr in that case as well
-                ss_cfg = 2
-            else:
-                # This branch is reached if Schnorr is slow but ECDSA is fast
-                # (core's secp256k1 lib was found which lacks Schnorr) -- so we
-                # default it to off. Also if watching only we default off.
-                ss_cfg = 0
-        return bool(ss_cfg)
+        return False
 
     def set_schnorr_enabled(self, b: bool):
         ''' Enable schnorr for this wallet. Note that if Schnorr is not possible,

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -913,7 +913,7 @@ class ElectrumGui(QObject, PrintError):
                 self.tray.showMessage("Electron Cash", message, QSystemTrayIcon.Information, 20000)
 
     def is_cashaddr(self):
-        return bool(self.config.get('show_cashaddr', True))
+        return bool(self.config.get('show_cashaddr', False))
 
     def toggle_cashaddr(self, on = None):
         was = self.is_cashaddr()

--- a/electroncash_gui/qt/update_checker.py
+++ b/electroncash_gui/qt/update_checker.py
@@ -63,7 +63,7 @@ class UpdateChecker(QWidget, PrintError):
     _dl_prog = pyqtSignal(object, int) # [0 -> 100] range
 
     #url = "https://www.c3-soft.com/downloads/BitcoinCash/Electron-Cash/update_check" # Testing URL
-    url = "https://raw.github.com/Electron-Cash/Electron-Cash/master/contrib/update_checker/releases.json" # Release URL
+    url = "https://raw.github.com/RadiantBlockchain/electron-radiant/master/contrib/update_checker/releases.json" # Release URL
     download_url = "https://electroncash.org/#download"
 
     VERSION_ANNOUNCEMENT_SIGNING_ADDRESSES = (


### PR DESCRIPTION
Changed header hash to sha512/256
Set ASERT anchor and verification block
Disable CashAddr by default
Changed update URL to electron-radiant github address
Added pycryptodome to requirements.txt
Disabled Schnorr
Added hashOutputHashes to sighash preimage
Changed window title to Electron Radiant
Changed user directories to .electron-radiant and ElectronRadiant
Changed BCH to RAD
Multiplied fee rates by 1000